### PR TITLE
config: jacoco 플러그인 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,16 +5,15 @@ plugins {
     id 'jacoco'
 }
 
-jacocoTestReport {
-    reports {
-        xml.enabled true
-    }
-}
-
 subprojects {
     apply plugin: 'java'
     apply plugin: 'org.springframework.boot'
     apply plugin: 'io.spring.dependency-management'
+    apply plugin: 'jacoco'
+
+    jacoco {
+        toolVersion = "$jacocoVersion"
+    }
 
     group = 'kr.co.yapp.cafe'
     version = '0.0.1-SNAPSHOT'
@@ -42,5 +41,13 @@ subprojects {
 
     tasks.named('test') {
         useJUnitPlatform()
+        finalizedBy jacocoTestReport
+    }
+
+    tasks.named('jacocoTestReport') {
+        dependsOn test
+        reports {
+            xml.enabled true
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,13 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.0.6' apply false
     id 'io.spring.dependency-management' version '1.1.0' apply false
+    id 'jacoco'
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ subprojects {
         dependsOn test
         reports {
             xml.enabled true
+            csv.enabled false
+            html.enabled false
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 springdocVersion=2.1.0
-jacocoVersion=0.8.8
+jacocoVersion=0.8.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 springdocVersion=2.1.0
+jacocoVersion=0.8.8


### PR DESCRIPTION
related #1 

- code coverage 수집 위해 jacoco 플러그인 추가

### References
- https://docs.gradle.org/current/userguide/jacoco_plugin.html
- https://docs.sonarcloud.io/enriching/test-coverage/java-test-coverage/