### PR TITLE
[feat]: member status, provider 정보 추가

### DIFF
--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/member/MemberAssembler.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/member/MemberAssembler.java
@@ -8,7 +8,9 @@ public class MemberAssembler {
     public MemberResponse toMemberResponse(Member member) {
         return new MemberResponse(
                 member.getMemberId(),
-                member.getName()
+                member.getName(),
+                member.getStatus(),
+                member.getAuthProviderType()
         );
     }
 }

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/member/MemberController.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/member/MemberController.java
@@ -25,9 +25,8 @@ public class MemberController {
     public ApiResponse<MemberResponse> getMyInfo(
             @AuthenticationPrincipal Long memberId
     ) {
-        Long testMemberId = 1L;
-        Member member = memberRepository.findById(testMemberId)
-                .orElseGet(() -> Member.from(MemberCreateVo.of("test", MemberStatus.ACTIVE, AuthProviderType.ANONYMOUS)));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
         MemberResponse memberResponse = memberAssembler.toMemberResponse(member);
         return ApiResponse.success(memberResponse);
     }

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/member/MemberController.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/member/MemberController.java
@@ -1,9 +1,7 @@
 package kr.co.yapp._22nd.coffice.ui.member;
 
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import kr.co.yapp._22nd.coffice.domain.member.Member;
-import kr.co.yapp._22nd.coffice.domain.member.MemberCreateVo;
-import kr.co.yapp._22nd.coffice.domain.member.MemberRepository;
+import kr.co.yapp._22nd.coffice.domain.member.*;
 import kr.co.yapp._22nd.coffice.infrastructure.springdoc.SpringdocConfig;
 import kr.co.yapp._22nd.coffice.ui.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -24,10 +22,14 @@ public class MemberController {
      */
     @SecurityRequirement(name = SpringdocConfig.SECURITY_SCHEME_NAME)
     @GetMapping("/me")
-    public Object getMyInfo(
+    public ApiResponse<MemberResponse> getMyInfo(
             @AuthenticationPrincipal Long memberId
     ) {
-        return null;
+        Long testMemberId = 1L;
+        Member member = memberRepository.findById(testMemberId)
+                .orElseGet(() -> Member.from(MemberCreateVo.of("test", MemberStatus.ACTIVE, AuthProviderType.ANONYMOUS)));
+        MemberResponse memberResponse = memberAssembler.toMemberResponse(member);
+        return ApiResponse.success(memberResponse);
     }
 
     /**
@@ -42,7 +44,7 @@ public class MemberController {
     ) {
         Long testMemberId = 1L;
         Member member = memberRepository.findById(testMemberId)
-                .orElseGet(() -> Member.from(MemberCreateVo.of("test")));
+                .orElseGet(() -> Member.from(MemberCreateVo.of("test", MemberStatus.ACTIVE, AuthProviderType.ANONYMOUS)));
         MemberResponse memberResponse = memberAssembler.toMemberResponse(member);
         LoginResponse loginResponse = new LoginResponse();
         String testAccessToken = "accessToken";

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/member/MemberResponse.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/member/MemberResponse.java
@@ -1,7 +1,11 @@
 package kr.co.yapp._22nd.coffice.ui.member;
 
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import kr.co.yapp._22nd.coffice.domain.member.AuthProviderType;
+import kr.co.yapp._22nd.coffice.domain.member.MemberStatus;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -12,4 +16,6 @@ public class MemberResponse {
     private Long memberId;
     @NotBlank
     private String name;
+    private MemberStatus status;
+    private AuthProviderType authProviderType;
 }

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/AuthProviderType.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/AuthProviderType.java
@@ -1,0 +1,7 @@
+package kr.co.yapp._22nd.coffice.domain.member;
+
+public enum AuthProviderType {
+    ANONYMOUS,
+    KAKAO,
+    APPLE
+}

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/Member.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/Member.java
@@ -21,6 +21,14 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
     private String name;
+
+    @Enumerated(EnumType.STRING)
+    private MemberStatus status;
+
+    private String authProviderUserId;
+    @Enumerated(EnumType.STRING)
+    private AuthProviderType authProviderType;
+
     @CreatedDate
     private LocalDateTime createdAt;
     @LastModifiedDate
@@ -29,6 +37,8 @@ public class Member {
     public static Member from(MemberCreateVo memberCreateVo) {
         Member member = new Member();
         member.name = memberCreateVo.getName();
+        member.status = memberCreateVo.getStatus();
+        member.authProviderType = memberCreateVo.getAuthProviderType();
         return member;
     }
 }

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberCreateVo.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberCreateVo.java
@@ -5,4 +5,6 @@ import lombok.Value;
 @Value(staticConstructor = "of")
 public class MemberCreateVo {
     String name;
+    MemberStatus status;
+    AuthProviderType authProviderType;
 }

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberStatus.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberStatus.java
@@ -1,0 +1,6 @@
+package kr.co.yapp._22nd.coffice.domain.member;
+
+public enum MemberStatus {
+    ACTIVE,
+    WITHDRAWAL
+}


### PR DESCRIPTION
- 회원 도메인에 회원 상태와 auth provider 정보를 추가했습니다
- 내 정보 조회 api(/me) mock 응답 처리했습니다