### PR TITLE
feat: 탈퇴회원 로그인 예외처리

### DIFF
--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberRepository.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberRepository.java
@@ -1,10 +1,11 @@
 package kr.co.yapp._22nd.coffice.domain.member;
 
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderStatus;
 import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByAuthProviders_AuthProviderTypeAndAuthProviders_AuthProviderUserId(AuthProviderType authProviderType, String authProviderUserId);
+    Optional<Member> findByAuthProviders_AuthProviderTypeAndAuthProviders_AuthProviderUserIdAndAuthProviders_AuthProviderStatus(AuthProviderType authProviderType, String authProviderUserId, AuthProviderStatus authProviderStatus);
 }

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberService.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberService.java
@@ -1,13 +1,15 @@
 package kr.co.yapp._22nd.coffice.domain.member;
 
-import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderType;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderVo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
 
 public interface MemberService {
     Member getMember(Long memberId);
 
-    Member getMember(AuthProviderType authProviderType, String authProviderUserId);
+    Optional<Member> getMember(AuthProviderVo authProviderVo);
 
     Page<Member> findAll(Pageable pageable);
 

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberServiceImpl.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberServiceImpl.java
@@ -2,11 +2,14 @@ package kr.co.yapp._22nd.coffice.domain.member;
 
 import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderCreateVo;
 import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderType;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderVo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -21,9 +24,12 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public Member getMember(AuthProviderType authProviderType, String authProviderUserId) {
-        return memberRepository.findByAuthProviders_AuthProviderTypeAndAuthProviders_AuthProviderUserId(authProviderType, authProviderUserId)
-                .orElseThrow(() -> new MemberNotFoundException(authProviderType, authProviderUserId));
+    public Optional<Member> getMember(AuthProviderVo authProviderVo) {
+        return memberRepository.findByAuthProviders_AuthProviderTypeAndAuthProviders_AuthProviderUserIdAndAuthProviders_AuthProviderStatus(
+                authProviderVo.getAuthProviderType(),
+                authProviderVo.getAuthProviderUserId(),
+                authProviderVo.getAuthProviderStatus()
+        );
     }
 
     @Override


### PR DESCRIPTION
탈퇴한 회원이 다시 로그인(회원가입) 시도시 새로 회원가입 하도록 수정.

테스트 내용
- 새로 회원가입 / 로그인 과 예외상황들 (related #83 )
- 유저 탈퇴처리(MemberStatus WITHDRAWAL) 후 동일한 authProvider 정보로 회원가입 시도