### PR TITLE
feat: data 가 배열이면 page 필드 항상 추가

### DIFF
--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/ApiResponse.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/ApiResponse.java
@@ -52,7 +52,7 @@ public class ApiResponse<T> {
     }
 
     public static <T> ApiResponse<List<T>> success(List<T> list) {
-        return new ApiResponse<>(ResultCode.SUCCESS, list);
+        return new ApiResponse<>(ResultCode.SUCCESS, list, PageResponse.unpaged());
     }
 
     public static <T> ApiResponse<List<T>> success(Slice<T> slice) {
@@ -64,7 +64,7 @@ public class ApiResponse<T> {
     }
 
     public static <T> ApiResponse<List<T>> success(Page<T> page) {
-        return new ApiResponse<>(ResultCode.SUCCESS, page.getContent());
+        return new ApiResponse<>(ResultCode.SUCCESS, page.getContent(), PageResponse.from(page));
     }
 
     public static <T> ApiResponse<T> failure() {

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/PageResponse.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/PageResponse.java
@@ -1,9 +1,19 @@
 package kr.co.yapp._22nd.coffice.ui;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
 
 public record PageResponse(boolean hasNext) {
+
+    public static PageResponse unpaged() {
+        return new PageResponse(false);
+    }
+
     public static PageResponse from(Slice<?> slice) {
         return new PageResponse(slice.hasNext());
+    }
+
+    public static PageResponse from(Page<?> page) {
+        return new PageResponse(page.hasNext());
     }
 }


### PR DESCRIPTION
## 변경사항
### AS-IS
- 검색 API 만 ApiResponse.page 필드 사용하고, 나머지 API 는 목록을 응답하더라도 page 필드를 사용안함
### TO-BE
- ApiResponse.data 가 배열인 모든 API 는 page 필드를 채워서 응답함

## 테스트
- 카페 목록 조회, 최근검색어 목록 조회 API 호출시`page.hasNext` 필드 추가된 것 확인