### PR TITLE
feat: 최근검색어 API 개선

### DIFF
--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/application/PlaceApplicationService.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/application/PlaceApplicationService.java
@@ -34,12 +34,15 @@ public class PlaceApplicationService {
             PlaceSearchRequestVo placeSearchRequestVo,
             CursorPageable<Double> cursorPageable
     ) {
-        searchRequestedEventPublisher.publish(
-                new SearchRequestedEvent(
-                        memberId,
-                        placeSearchRequestVo.getSearchText()
-                )
-        );
+        if (cursorPageable.isInitial()) {
+            searchRequestedEventPublisher.publish(
+                    new SearchRequestedEvent(
+                            memberId,
+                            placeSearchRequestVo.getSearchText()
+                    )
+            );
+        }
+
         Set<Long> archivedPlaceIds = placeArchiveApplicationService.getArchivedPlaces(memberId)
                 .stream()
                 .map(Place::getPlaceId)

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/application/search/SearchEventHandler.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/application/search/SearchEventHandler.java
@@ -15,7 +15,7 @@ public class SearchEventHandler implements CofficeDomainEvent {
     @Async
     @EventListener(SearchRequestedEvent.class)
     public void handleSearchRequested(SearchRequestedEvent event) {
-        searchWordApplicationService.create(
+        searchWordApplicationService.add(
                 event.getMemberId(),
                 event.getText()
         );

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/application/search/SearchWordApplicationService.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/application/search/SearchWordApplicationService.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class SearchWordApplicationService {
     private final SearchWordService searchWordService;
 
-    public SearchWord create(Long memberId, String text) {
+    public SearchWord add(Long memberId, String text) {
         return searchWordService.create(memberId, text);
     }
 

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/search/SearchWordRepository.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/search/SearchWordRepository.java
@@ -11,4 +11,6 @@ public interface SearchWordRepository extends JpaRepository<SearchWord, Long> {
     List<SearchWord> findByMemberIdAndDeletedFalseOrderByCreatedAtDesc(Long memberId);
 
     List<SearchWord> findByMemberIdAndDeletedFalse(Long memberId);
+
+    List<SearchWord> findByMemberIdAndTextAndDeletedFalse(Long memberId, String text);
 }

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/search/SearchWordServiceImpl.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/search/SearchWordServiceImpl.java
@@ -16,6 +16,8 @@ public class SearchWordServiceImpl implements SearchWordService {
     @Override
     @Transactional
     public SearchWord create(Long memberId, String text) {
+        searchWordRepository.findByMemberIdAndTextAndDeletedFalse(memberId, text)
+                .forEach(SearchWord::delete);
         SearchWord searchWord = SearchWord.of(memberId, text);
         return searchWordRepository.save(searchWord);
     }

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/search/SearchWordServiceImpl.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/search/SearchWordServiceImpl.java
@@ -3,6 +3,7 @@ package kr.co.yapp._22nd.coffice.domain.search;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 
@@ -16,6 +17,9 @@ public class SearchWordServiceImpl implements SearchWordService {
     @Override
     @Transactional
     public SearchWord create(Long memberId, String text) {
+        if (!StringUtils.hasText(text)) {
+            throw new IllegalArgumentException("'text' must not be empty or blank. text: " + text);
+        }
         searchWordRepository.findByMemberIdAndTextAndDeletedFalse(memberId, text)
                 .forEach(SearchWord::delete);
         SearchWord searchWord = SearchWord.of(memberId, text);


### PR DESCRIPTION
## AS-IS
- 검색결과가 스크롤 되어서 여러번 검색 API를 호출하는 경우, 매번 검색어 새로 저장함
- 같은 검색어로 여러번 검색하면 여러개의 최근검색어가 나옴
- 빈문자나 공백문자로만 이루어진 검색어도 저장함

## TO-BE
- 검색결과가 스크롤 되어서 여러번 검색 API를 호출하는 경우, `처음` 검색 요청할 때만 검색어로 저장함
- 같은 검색어로 여러번 검색하면 가장 최근의 1개만 나옴
- 빈문자나 공백문자로만 이루어진 검색어는 저장 안함