### PR TITLE
feat: OCP 원리를 적용한 로그인 예제 코드

### DIFF
--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/application/login/LoginApplicationService.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/application/login/LoginApplicationService.java
@@ -1,13 +1,18 @@
 package kr.co.yapp._22nd.coffice.application.login;
 
+import kr.co.yapp._22nd.coffice.domain.LoginRequestVo;
+import kr.co.yapp._22nd.coffice.domain.LoginService;
+import kr.co.yapp._22nd.coffice.domain.UnsupportedLoginTypeException;
 import kr.co.yapp._22nd.coffice.domain.member.Member;
 import kr.co.yapp._22nd.coffice.domain.member.MemberCommandService;
 import kr.co.yapp._22nd.coffice.domain.member.MemberQueryService;
-import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderStatus;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderCreateVo;
 import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderVo;
 import kr.co.yapp._22nd.coffice.infrastructure.spring.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -15,17 +20,27 @@ public class LoginApplicationService {
     private final MemberQueryService memberQueryService;
     private final MemberCommandService memberCommandService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final List<LoginService> loginServices;
 
     public LoginResponseVo login(LoginRequestVo loginRequestVo) {
-        Member member = memberQueryService.getMember(
-                        AuthProviderVo.of(
-                                loginRequestVo.getAuthProviderType(),
-                                loginRequestVo.getAuthProviderUserId(),
-                                AuthProviderStatus.ACTIVE
-                        )
-                )
-                .orElseGet(() -> memberCommandService.join(loginRequestVo.getAuthProviderUserId()));
+        // 로그인 방식에 맞게 외부 인증 서비스에서의 id 조회
+        LoginService loginService = resolveLoginService(loginRequestVo);
+        AuthProviderCreateVo authProviderCreateVo = loginService.login(loginRequestVo);
+
+        // coffice 데이터 기반으로 로그인 처리
+        Member member = memberQueryService.getMember(AuthProviderVo.active(authProviderCreateVo))
+                .orElseGet(() -> memberCommandService.join(authProviderCreateVo));
         String token = jwtTokenProvider.generateToken(member.getMemberId());
         return LoginResponseVo.of(token, member);
+    }
+
+    /**
+     * 로그인 방식에 맞는 LoginService 를 찾아서 반환.
+     */
+    private LoginService resolveLoginService(LoginRequestVo loginRequestVo) {
+        return loginServices.stream()
+                .filter(loginService -> loginService.supports(loginRequestVo))
+                .findFirst()
+                .orElseThrow(() -> new UnsupportedLoginTypeException("지원하지 않는 로그인 타입입니다. loginRequestVo: " + loginRequestVo));
     }
 }

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/domain/LoginRequestVo.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/domain/LoginRequestVo.java
@@ -1,4 +1,4 @@
-package kr.co.yapp._22nd.coffice.application.login;
+package kr.co.yapp._22nd.coffice.domain;
 
 import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderType;
 import lombok.Value;

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/domain/LoginService.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/domain/LoginService.java
@@ -1,0 +1,9 @@
+package kr.co.yapp._22nd.coffice.domain;
+
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderCreateVo;
+
+public interface LoginService {
+    AuthProviderCreateVo login(LoginRequestVo loginRequestVo);
+
+    boolean supports(LoginRequestVo loginRequestVo);
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/domain/ProviderUserInfo.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/domain/ProviderUserInfo.java
@@ -1,0 +1,8 @@
+package kr.co.yapp._22nd.coffice.domain;
+
+import lombok.Value;
+
+@Value(staticConstructor = "of")
+public class ProviderUserInfo {
+    String id;
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/domain/UnsupportedLoginTypeException.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/domain/UnsupportedLoginTypeException.java
@@ -1,0 +1,7 @@
+package kr.co.yapp._22nd.coffice.domain;
+
+public class UnsupportedLoginTypeException extends BadRequestException {
+    public UnsupportedLoginTypeException(String message) {
+        super(message);
+    }
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/apple/AppleLoginService.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/apple/AppleLoginService.java
@@ -1,0 +1,24 @@
+package kr.co.yapp._22nd.coffice.infrastructure.apple;
+
+import kr.co.yapp._22nd.coffice.domain.LoginRequestVo;
+import kr.co.yapp._22nd.coffice.domain.LoginService;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderCreateVo;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderType;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AppleLoginService implements LoginService {
+    @Override
+    public AuthProviderCreateVo login(LoginRequestVo loginRequestVo) {
+        // 1. 예외 던지거나
+        // throw new IllegalStateException("아직 구현되지 않은 기능입니다");
+
+        // 2. mock 구현
+        return AuthProviderCreateVo.of(AuthProviderType.APPLE, "appleUserId");
+    }
+
+    @Override
+    public boolean supports(LoginRequestVo loginRequestVo) {
+        return loginRequestVo.getAuthProviderType() == AuthProviderType.APPLE;
+    }
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/coffice/AnonymousLoginService.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/coffice/AnonymousLoginService.java
@@ -1,0 +1,23 @@
+package kr.co.yapp._22nd.coffice.infrastructure.coffice;
+
+import kr.co.yapp._22nd.coffice.domain.LoginRequestVo;
+import kr.co.yapp._22nd.coffice.domain.LoginService;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderCreateVo;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderType;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AnonymousLoginService implements LoginService {
+    @Override
+    public AuthProviderCreateVo login(LoginRequestVo loginRequestVo) {
+        return AuthProviderCreateVo.of(
+                AuthProviderType.ANONYMOUS,
+                loginRequestVo.getAuthProviderUserId()
+        );
+    }
+
+    @Override
+    public boolean supports(LoginRequestVo loginRequestVo) {
+        return loginRequestVo.getAuthProviderType() == AuthProviderType.ANONYMOUS;
+    }
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/kakao/KakaoApiClient.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/kakao/KakaoApiClient.java
@@ -1,0 +1,50 @@
+package kr.co.yapp._22nd.coffice.infrastructure.kakao;
+
+import kr.co.yapp._22nd.coffice.domain.ProviderUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoApiClient {
+    private final RestTemplate kakaoResetTemplate;
+
+    /**
+     * 카카오 사용자 정보 가져오기
+     *
+     * @see "https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info"
+     */
+    ProviderUserInfo getUserInfo(String kakaoAccessToken) {
+        URI url = UriComponentsBuilder.fromHttpUrl("https://kapi.kakao.com/v2/user/me")
+                .build()
+                .toUri();
+
+        try {
+            MultiValueMap<String, String> headerMap = new LinkedMultiValueMap<>();
+            headerMap.put("Authorization", List.of("Bearer " + kakaoAccessToken));
+            ResponseEntity<KakaoUserMeDto> responseEntity = kakaoResetTemplate.exchange(
+                    new RequestEntity<>(headerMap, HttpMethod.GET, url),
+                    KakaoUserMeDto.class
+            );
+            KakaoUserMeDto kakaoUserMeDto = responseEntity.getBody();
+            Assert.notNull(kakaoUserMeDto, "'kakaoUserMeDto' must not be null");
+            return ProviderUserInfo.of(
+                    kakaoUserMeDto.getId()
+            );
+        } catch (RestClientException e) {
+            throw new KakaoApiFailedException("카카오 사용자 정보 가져오기 API 호출에 실패했습니다.", e);
+        }
+    }
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/kakao/KakaoApiFailedException.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/kakao/KakaoApiFailedException.java
@@ -1,0 +1,13 @@
+package kr.co.yapp._22nd.coffice.infrastructure.kakao;
+
+import kr.co.yapp._22nd.coffice.domain.CofficeException;
+
+public class KakaoApiFailedException extends CofficeException {
+    public KakaoApiFailedException(String message) {
+        super(message);
+    }
+
+    public KakaoApiFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/kakao/KakaoConfig.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/kakao/KakaoConfig.java
@@ -1,0 +1,19 @@
+package kr.co.yapp._22nd.coffice.infrastructure.kakao;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class KakaoConfig {
+    @Bean
+    public RestTemplate kakaoRestTemplate() {
+        return new RestTemplateBuilder()
+                .setConnectTimeout(Duration.ofSeconds(1))
+                .setReadTimeout(Duration.ofSeconds(1))
+                .build();
+    }
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/kakao/KakaoLoginService.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/kakao/KakaoLoginService.java
@@ -1,0 +1,31 @@
+package kr.co.yapp._22nd.coffice.infrastructure.kakao;
+
+import kr.co.yapp._22nd.coffice.domain.LoginRequestVo;
+import kr.co.yapp._22nd.coffice.domain.LoginService;
+import kr.co.yapp._22nd.coffice.domain.ProviderUserInfo;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderCreateVo;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoLoginService implements LoginService {
+    private final KakaoApiClient kakaoApiClient;
+
+    @Override
+    public AuthProviderCreateVo login(LoginRequestVo loginRequestVo) {
+        if (loginRequestVo.getAuthProviderType() != AuthProviderType.KAKAO) {
+            throw new IllegalArgumentException("KakaoLoginService only supports KAKAO. loginRequestVo: " + loginRequestVo);
+        }
+        String kakaoAccessToken = loginRequestVo.getAuthProviderUserId();
+        ProviderUserInfo userInfo = kakaoApiClient.getUserInfo(kakaoAccessToken);
+        String kakaoUserId = userInfo.getId();
+        return AuthProviderCreateVo.of(AuthProviderType.KAKAO, kakaoUserId);
+    }
+
+    @Override
+    public boolean supports(LoginRequestVo loginRequestVo) {
+        return loginRequestVo.getAuthProviderType() == AuthProviderType.KAKAO;
+    }
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/kakao/KakaoUserMeDto.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/kakao/KakaoUserMeDto.java
@@ -1,0 +1,8 @@
+package kr.co.yapp._22nd.coffice.infrastructure.kakao;
+
+import lombok.Data;
+
+@Data
+public class KakaoUserMeDto {
+    private String id;
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/member/LoginAssembler.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/member/LoginAssembler.java
@@ -1,7 +1,7 @@
 package kr.co.yapp._22nd.coffice.ui.member;
 
-import kr.co.yapp._22nd.coffice.application.login.LoginRequestVo;
 import kr.co.yapp._22nd.coffice.application.login.LoginResponseVo;
+import kr.co.yapp._22nd.coffice.domain.LoginRequestVo;
 import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberCommandService.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberCommandService.java
@@ -1,5 +1,7 @@
 package kr.co.yapp._22nd.coffice.domain.member;
 
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderCreateVo;
+
 public interface MemberCommandService {
-    Member join(String authProviderUserId);
+    Member join(AuthProviderCreateVo authProviderCreateVo);
 }

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberCommandServiceImpl.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberCommandServiceImpl.java
@@ -1,7 +1,6 @@
 package kr.co.yapp._22nd.coffice.domain.member;
 
 import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderCreateVo;
-import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderType;
 import kr.co.yapp._22nd.coffice.domain.member.name.NameGenerationService;
 import kr.co.yapp._22nd.coffice.domain.place.folder.PlaceFolderCreateVo;
 import kr.co.yapp._22nd.coffice.domain.place.folder.PlaceFolderService;
@@ -19,14 +18,19 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     @Override
     @Transactional
-    public Member join(String authProviderUserId) {
+    public Member join(AuthProviderCreateVo authProviderCreateVo) {
+        String name = generateName();
+        Member newMember = Member.from(MemberCreateVo.of(name, authProviderCreateVo));
+        memberRepository.save(newMember);
+        placeFolderService.create(newMember.getMemberId(), PlaceFolderCreateVo.defaultFolder());
+        return newMember;
+    }
+
+    private String generateName() {
         String name;
         do {
             name = nameGenerationService.generateRandomName();
         } while (memberRepository.existsByName(name));
-        Member newMember = Member.from(MemberCreateVo.of(name, AuthProviderCreateVo.of(AuthProviderType.ANONYMOUS, authProviderUserId)));
-        memberRepository.save(newMember);
-        placeFolderService.create(newMember.getMemberId(), PlaceFolderCreateVo.defaultFolder());
-        return newMember;
+        return name;
     }
 }

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/authProvider/AuthProviderVo.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/authProvider/AuthProviderVo.java
@@ -15,4 +15,12 @@ public class AuthProviderVo {
                 authProvider.getAuthProviderStatus()
         );
     }
+
+    public static AuthProviderVo active(AuthProviderCreateVo authProviderCreateVo) {
+        return new AuthProviderVo(
+                authProviderCreateVo.getAuthProviderType(),
+                authProviderCreateVo.getAuthProviderUserId(),
+                AuthProviderStatus.ACTIVE
+        );
+    }
 }


### PR DESCRIPTION
- 이해를 돕기 위해 작성한 예제 코드입니다. 직접 실행하거나 테스트해보진 않았어요. 
- 인증 제공 외부 서비스가 늘어남에 따라, 
   1. 새로운 로그인 방식을 어떻게 제공하는지와 (LoginService 인터페이스 및 구현한 클래스 참고)
      - 기기마다 식별가능한값(현재는 UUID) 으로 coffice 계정을 식별하는 `익명 로그인 (=둘러보기)` 
      - 카카오 사용자 ID 로 coffice 계정을 식별하는 `카카오 로그인`
      - 애플 사용자 ID 로 coffice 계정을 식별하는 `애플 로그인`
      - 이후 다른 방식 추가 가능
   2. 공통로직인 LoginApplicationService, MemberCommandService 가 어떻게 영향받는지에 주의하면서 봐주세요