### PR TITLE
feat: 회원 탈퇴, 연결 (OAuth 서버에 탈퇴 요청 미구현)

### DIFF
--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/application/withdrawal/WithdrawalApplicationService.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/application/withdrawal/WithdrawalApplicationService.java
@@ -1,0 +1,51 @@
+package kr.co.yapp._22nd.coffice.application.withdrawal;
+
+import kr.co.yapp._22nd.coffice.domain.DisconnectRequestVo;
+import kr.co.yapp._22nd.coffice.domain.DisconnectService;
+import kr.co.yapp._22nd.coffice.domain.UnsupportedWithdrwalTypeException;
+import kr.co.yapp._22nd.coffice.domain.member.Member;
+import kr.co.yapp._22nd.coffice.domain.member.MemberCommandService;
+import kr.co.yapp._22nd.coffice.domain.member.MemberQueryService;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderDeleteVo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class WithdrawalApplicationService {
+    private final List<DisconnectService> disconnectServices;
+    private final MemberCommandService memberCommandService;
+    private final MemberQueryService memberQueryService;
+
+    public void withdraw(Long memberId) {
+        Member member = memberQueryService.getMember(memberId);
+        List<AuthProviderDeleteVo> authProviderDeleteVos = member.getAuthProviders().stream()
+                .map(authProvider -> sendOAuthDisconnectRequest(
+                        memberId,
+                        DisconnectRequestVo.of(authProvider.getAuthProviderType()))
+                )
+                .collect(Collectors.toList());
+        memberCommandService.disconnect(memberId, authProviderDeleteVos);
+    }
+
+    public void disconnectAuthProvider(Long memberId, DisconnectRequestVo disconnectRequestVo) {
+        List<AuthProviderDeleteVo> authProviderDeleteVo = Collections.singletonList(sendOAuthDisconnectRequest(memberId, disconnectRequestVo));
+        memberCommandService.disconnect(memberId, authProviderDeleteVo);
+    }
+
+    private AuthProviderDeleteVo sendOAuthDisconnectRequest(Long memberId, DisconnectRequestVo disconnectRequestVo) {
+        DisconnectService disconnectService = resolveDisconnectService(disconnectRequestVo);
+        return disconnectService.disconnect(memberId, disconnectRequestVo);
+    }
+
+    private DisconnectService resolveDisconnectService(DisconnectRequestVo disconnectRequestVo) {
+        return disconnectServices.stream()
+                .filter(disconnectService -> disconnectService.supports(disconnectRequestVo))
+                .findFirst()
+                .orElseThrow(() -> new UnsupportedWithdrwalTypeException(disconnectRequestVo));
+    }
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/domain/DisconnectRequestVo.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/domain/DisconnectRequestVo.java
@@ -1,0 +1,9 @@
+package kr.co.yapp._22nd.coffice.domain;
+
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderType;
+import lombok.Value;
+
+@Value(staticConstructor = "of")
+public class DisconnectRequestVo {
+    AuthProviderType authProviderType;
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/domain/DisconnectService.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/domain/DisconnectService.java
@@ -1,0 +1,8 @@
+package kr.co.yapp._22nd.coffice.domain;
+
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderDeleteVo;
+
+public interface DisconnectService {
+    AuthProviderDeleteVo disconnect(Long memberId, DisconnectRequestVo disconnectRequestVo);
+    boolean supports(DisconnectRequestVo disconnectRequestVo);
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/domain/UnsupportedWithdrwalTypeException.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/domain/UnsupportedWithdrwalTypeException.java
@@ -1,0 +1,7 @@
+package kr.co.yapp._22nd.coffice.domain;
+
+public class UnsupportedWithdrwalTypeException extends BadRequestException {
+    public UnsupportedWithdrwalTypeException(DisconnectRequestVo disconnectRequestVo) {
+        super("지원하지 않는 회원 탈퇴 타입입니다. disconnectRequestVo: " + disconnectRequestVo);
+    }
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/apple/AppleDisconnectService.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/apple/AppleDisconnectService.java
@@ -1,0 +1,25 @@
+package kr.co.yapp._22nd.coffice.infrastructure.apple;
+
+import kr.co.yapp._22nd.coffice.domain.DisconnectRequestVo;
+import kr.co.yapp._22nd.coffice.domain.DisconnectService;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderDeleteVo;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AppleDisconnectService implements DisconnectService {
+    @Override
+    public AuthProviderDeleteVo disconnect(Long memberId, DisconnectRequestVo disconnectRequestVo) {
+        /* TODO: Apple 탈퇴 API 호출 (block() (동기 요청)) */
+        return AuthProviderDeleteVo.of(
+                AuthProviderType.APPLE
+        );
+    }
+
+    @Override
+    public boolean supports(DisconnectRequestVo disconnectRequestVo) {
+        return disconnectRequestVo.getAuthProviderType() == AuthProviderType.APPLE;
+    }
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/coffice/AnonymousDisconnectService.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/coffice/AnonymousDisconnectService.java
@@ -1,0 +1,24 @@
+package kr.co.yapp._22nd.coffice.infrastructure.coffice;
+
+import kr.co.yapp._22nd.coffice.domain.DisconnectRequestVo;
+import kr.co.yapp._22nd.coffice.domain.DisconnectService;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderDeleteVo;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AnonymousDisconnectService implements DisconnectService {
+    @Override
+    public AuthProviderDeleteVo disconnect(Long memberId, DisconnectRequestVo disconnectRequestVo) {
+        return AuthProviderDeleteVo.of(
+                AuthProviderType.ANONYMOUS
+        );
+    }
+
+    @Override
+    public boolean supports(DisconnectRequestVo disconnectRequestVo) {
+        return disconnectRequestVo.getAuthProviderType() == AuthProviderType.ANONYMOUS;
+    }
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/kakao/KakaoDisconnectService.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/infrastructure/kakao/KakaoDisconnectService.java
@@ -1,0 +1,25 @@
+package kr.co.yapp._22nd.coffice.infrastructure.kakao;
+
+import kr.co.yapp._22nd.coffice.domain.DisconnectRequestVo;
+import kr.co.yapp._22nd.coffice.domain.DisconnectService;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderDeleteVo;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoDisconnectService implements DisconnectService {
+    @Override
+    public AuthProviderDeleteVo disconnect(Long memberId, DisconnectRequestVo disconnectRequestVo) {
+        /* TODO: kakao 탈퇴 API 호출 (block() (동기 요청)) */
+        return AuthProviderDeleteVo.of(
+                AuthProviderType.KAKAO
+        );
+    }
+
+    @Override
+    public boolean supports(DisconnectRequestVo disconnectRequestVo) {
+        return disconnectRequestVo.getAuthProviderType() == AuthProviderType.KAKAO;
+    }
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/member/DisconnectReqeust.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/member/DisconnectReqeust.java
@@ -1,0 +1,11 @@
+package kr.co.yapp._22nd.coffice.ui.member;
+
+import jakarta.validation.constraints.NotNull;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderType;
+import lombok.Data;
+
+@Data
+public class DisconnectReqeust {
+    @NotNull
+    private AuthProviderType authProviderType;
+}

--- a/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/member/MemberController.java
+++ b/coffice-api/src/main/java/kr/co/yapp/_22nd/coffice/ui/member/MemberController.java
@@ -3,6 +3,8 @@ package kr.co.yapp._22nd.coffice.ui.member;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
 import kr.co.yapp._22nd.coffice.application.login.LoginApplicationService;
+import kr.co.yapp._22nd.coffice.application.withdrawal.WithdrawalApplicationService;
+import kr.co.yapp._22nd.coffice.domain.DisconnectRequestVo;
 import kr.co.yapp._22nd.coffice.domain.member.*;
 import kr.co.yapp._22nd.coffice.infrastructure.springdoc.SpringdocConfig;
 import kr.co.yapp._22nd.coffice.ui.ApiResponse;
@@ -18,6 +20,7 @@ public class MemberController {
     private final MemberAssembler memberAssembler;
     private final LoginApplicationService loginApplicationService;
     private final LoginAssembler loginAssembler;
+    private final WithdrawalApplicationService withdrawalApplicationService;
 
     /**
      * 내 정보 조회
@@ -86,11 +89,24 @@ public class MemberController {
      */
     @SecurityRequirement(name = SpringdocConfig.SECURITY_SCHEME_NAME)
     @PostMapping("/withdraw")
-    public void withdraw(
+    public ApiResponse<?> withdraw(
             @AuthenticationPrincipal Long memberId
     ) {
-        // TODO: 회원탈퇴
+        withdrawalApplicationService.withdraw(memberId);
+        return ApiResponse.success();
     }
 
-    // TODO: 카카오 연결 끊기 (https://developers.kakao.com/docs/latest/ko/kakaologin/callback#unlink)
+
+    /**
+     * 연결 끊기
+     */
+    @SecurityRequirement(name = SpringdocConfig.SECURITY_SCHEME_NAME)
+    @PostMapping("/disconnect")
+    public ApiResponse<?> disconnect(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody DisconnectReqeust disconnectReqeust
+    ) {
+        withdrawalApplicationService.disconnectAuthProvider(memberId, DisconnectRequestVo.of(disconnectReqeust.getAuthProviderType()));
+        return ApiResponse.success();
+    }
 }

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/Member.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/Member.java
@@ -3,6 +3,8 @@ package kr.co.yapp._22nd.coffice.domain.member;
 import jakarta.persistence.*;
 import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProvider;
 import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderCreateVo;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderDeleteVo;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderStatus;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -13,6 +15,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 // TODO: 권한, fcmToken
 @Entity
@@ -48,5 +51,30 @@ public class Member {
 
     public void addAuthProvider(AuthProviderCreateVo authProviderCreateVo) {
         this.authProviders.add(AuthProvider.from(authProviderCreateVo));
+    }
+
+    public void deleteAuthProvider(AuthProviderDeleteVo authProviderDeleteVo) {
+        if (this.authProviders == null || this.authProviders.isEmpty()) {
+            return;
+        }
+        this.authProviders = this.authProviders.stream()
+                .peek(authProvider -> {
+                    if(authProvider.getAuthProviderType() == authProviderDeleteVo.getAuthProviderType() && authProvider.getAuthProviderStatus() == AuthProviderStatus.ACTIVE) {
+                        authProvider.delete();
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    public boolean activeAuthProviderExists() {
+        if (this.authProviders == null || this.authProviders.isEmpty()) {
+            return false;
+        }
+        return this.authProviders.stream()
+                .anyMatch(authProvider -> authProvider.getAuthProviderStatus() == AuthProviderStatus.ACTIVE);
+    }
+
+    public void withdraw() {
+        this.status = MemberStatus.WITHDRAWAL;
     }
 }

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberCommandService.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberCommandService.java
@@ -1,9 +1,14 @@
 package kr.co.yapp._22nd.coffice.domain.member;
 
 import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderCreateVo;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderDeleteVo;
+
+import java.util.List;
 
 public interface MemberCommandService {
     Member join(AuthProviderCreateVo authProviderCreateVo);
 
     Member connect(Long memberId, AuthProviderCreateVo authProviderCreateVo);
+
+    void disconnect(Long memberId, List<AuthProviderDeleteVo> authProviderDeleteVos);
 }

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberCommandServiceImpl.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/MemberCommandServiceImpl.java
@@ -1,15 +1,15 @@
 package kr.co.yapp._22nd.coffice.domain.member;
 
 import kr.co.yapp._22nd.coffice.domain.BadRequestException;
-import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderCreateVo;
-import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderStatus;
-import kr.co.yapp._22nd.coffice.domain.member.authProvider.AuthProviderType;
+import kr.co.yapp._22nd.coffice.domain.member.authProvider.*;
 import kr.co.yapp._22nd.coffice.domain.member.name.NameGenerationService;
 import kr.co.yapp._22nd.coffice.domain.place.folder.PlaceFolderCreateVo;
 import kr.co.yapp._22nd.coffice.domain.place.folder.PlaceFolderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional
@@ -35,6 +35,17 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
         member.addAuthProvider(authProviderCreateVo);
         return memberRepository.save(member);
+    }
+
+    @Override
+    public void disconnect(Long memberId, List<AuthProviderDeleteVo> authProviderDeleteVos) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(memberId));
+        authProviderDeleteVos.forEach(member::deleteAuthProvider);
+        if (!member.activeAuthProviderExists()) {
+            member.withdraw();
+        }
+        memberRepository.save(member);
     }
 
     private String generateName() {

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/authProvider/AuthProvider.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/authProvider/AuthProvider.java
@@ -3,16 +3,26 @@ package kr.co.yapp._22nd.coffice.domain.member.authProvider;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
 
 @Getter
 @ToString
 @Embeddable
+@EntityListeners(AuditingEntityListener.class)
 public class AuthProvider {
     @Enumerated(EnumType.STRING)
     private AuthProviderType authProviderType;
     private String authProviderUserId;
     @Enumerated(EnumType.STRING)
     private AuthProviderStatus authProviderStatus;
+    @CreatedDate
+    private LocalDateTime createdAt;
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
 
     public static AuthProvider from(AuthProviderCreateVo authProviderCreateVo) {
         AuthProvider authProvider = new AuthProvider();
@@ -20,5 +30,9 @@ public class AuthProvider {
         authProvider.authProviderUserId = authProviderCreateVo.getAuthProviderUserId();
         authProvider.authProviderStatus = AuthProviderStatus.ACTIVE;
         return authProvider;
+    }
+
+    public void delete() {
+        this.authProviderStatus = AuthProviderStatus.WITHDRAWAL;
     }
 }

--- a/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/authProvider/AuthProviderDeleteVo.java
+++ b/coffice-domain/src/main/java/kr/co/yapp/_22nd/coffice/domain/member/authProvider/AuthProviderDeleteVo.java
@@ -1,0 +1,8 @@
+package kr.co.yapp._22nd.coffice.domain.member.authProvider;
+
+import lombok.Value;
+
+@Value(staticConstructor = "of")
+public class AuthProviderDeleteVo {
+    AuthProviderType authProviderType;
+}


### PR DESCRIPTION
coffice 회원의 탈퇴 및 AuthProvider 연결 해제 처리 (상태값 업데이트).
Kakao, Apple과 같은 인증 제공자 서버에 실제로 연결 해제 요청은 아직 미구현이라 TODO로 주석 달아두었습니다.
그리고 트랜잭션 신경써서 처리하고자 했습니다.

## Test
1. 익명 가입 -> 탈퇴 / 연결 끊기
2. 카카오 가입 -> 탈퇴 / 연결 끊기 -> 다시 카카오 가입
3. 익명 가입 -> 카카오 연결 -> 탈퇴
4. 익명 가입 -> 카카오 연결 -> 모두 연결 끊기